### PR TITLE
Add JsonEventDeserializer for Kafka JSON events

### DIFF
--- a/libs/common-core/pom.xml
+++ b/libs/common-core/pom.xml
@@ -22,5 +22,23 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-logging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/libs/common-core/src/main/java/com/codemonk/common/constant/JsonConstants.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/constant/JsonConstants.java
@@ -1,0 +1,11 @@
+package com.codemonk.common.constant;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public final class JsonConstants {
+
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private JsonConstants() {
+    }
+}

--- a/libs/common-core/src/main/java/com/codemonk/common/service/JsonEventDeserializer.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/service/JsonEventDeserializer.java
@@ -1,0 +1,35 @@
+package com.codemonk.common.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Component
+public class JsonEventDeserializer implements Deserializer<Map<String, Object>> {
+
+    private static final TypeReference<Map<String, Object>> EVENT_TYPE = new TypeReference<>() {
+    };
+
+    private final ObjectMapper objectMapper;
+
+    public JsonEventDeserializer() {
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Override
+    public Map<String, Object> deserialize(String topic, byte[] data) {
+        if (data == null) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(data, EVENT_TYPE);
+        } catch (IOException e) {
+            throw new SerializationException("Failed to deserialize JSON event from topic '" + topic + "'", e);
+        }
+    }
+}

--- a/libs/common-core/src/main/java/com/codemonk/common/service/JsonEventDeserializer.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/service/JsonEventDeserializer.java
@@ -1,5 +1,6 @@
 package com.codemonk.common.service;
 
+import com.codemonk.common.constant.JsonConstants;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.common.errors.SerializationException;
@@ -18,7 +19,7 @@ public class JsonEventDeserializer implements Deserializer<Map<String, Object>> 
     private final ObjectMapper objectMapper;
 
     public JsonEventDeserializer() {
-        this.objectMapper = new ObjectMapper();
+        this.objectMapper = JsonConstants.OBJECT_MAPPER;
     }
 
     @Override

--- a/libs/common-core/src/test/java/com/codemonk/common/service/JsonEventDeserializerTest.java
+++ b/libs/common-core/src/test/java/com/codemonk/common/service/JsonEventDeserializerTest.java
@@ -1,0 +1,86 @@
+package com.codemonk.common.service;
+
+import org.apache.kafka.common.errors.SerializationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JsonEventDeserializerTest {
+
+    private JsonEventDeserializer deserializer;
+
+    @BeforeEach
+    void setUp() {
+        deserializer = new JsonEventDeserializer();
+    }
+
+    @Test
+    void shouldDeserializeFlatJsonObjectIntoMap() {
+        byte[] payload = """
+                {"eventId": "evt-1", "userId": 42, "active": true}
+                """.getBytes(StandardCharsets.UTF_8);
+
+        Map<String, Object> result = deserializer.deserialize("codemonk.events", payload);
+
+        assertEquals("evt-1", result.get("eventId"));
+        assertEquals(42, result.get("userId"));
+        assertEquals(true, result.get("active"));
+    }
+
+    @Test
+    void shouldDeserializeNestedJsonStructures() {
+        byte[] payload = """
+                {
+                  "eventType": "repository.indexed",
+                  "metadata": {"branch": "main", "commit": "abc123"},
+                  "tags": ["java", "kafka"]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+
+        Map<String, Object> result = deserializer.deserialize("codemonk.events", payload);
+
+        assertEquals("repository.indexed", result.get("eventType"));
+        assertTrue(result.get("metadata") instanceof Map);
+        assertEquals("main", ((Map<?, ?>) result.get("metadata")).get("branch"));
+        assertEquals(List.of("java", "kafka"), result.get("tags"));
+    }
+
+    @Test
+    void shouldReturnNullWhenDataIsNull() {
+        assertNull(deserializer.deserialize("codemonk.events", null));
+    }
+
+    @Test
+    void shouldThrowSerializationExceptionOnMalformedJson() {
+        byte[] payload = "not-valid-json".getBytes(StandardCharsets.UTF_8);
+
+        SerializationException exception = assertThrows(SerializationException.class,
+                () -> deserializer.deserialize("codemonk.events", payload));
+
+        assertTrue(exception.getMessage().contains("codemonk.events"));
+    }
+
+    @Test
+    void shouldThrowSerializationExceptionOnEmptyPayload() {
+        byte[] payload = new byte[0];
+
+        assertThrows(SerializationException.class,
+                () -> deserializer.deserialize("codemonk.events", payload));
+    }
+
+    @Test
+    void shouldThrowSerializationExceptionWhenJsonIsNotAnObject() {
+        byte[] payload = "[1, 2, 3]".getBytes(StandardCharsets.UTF_8);
+
+        assertThrows(SerializationException.class,
+                () -> deserializer.deserialize("codemonk.events", payload));
+    }
+}


### PR DESCRIPTION
## Summary

Implements `JsonEventDeserializer`, a Jackson-backed Kafka `Deserializer<Map<String, Object>>` in `libs/common-core`, as requested in #349.

## Context

Closes #349.

There was no existing Kafka (de)serializer code anywhere in the codebase to mirror conventions from — `spring-kafka` is currently only a declared (unused) dependency in `ai-service`, `knowledge-service`, and `code-analysis-service`, with no producers/consumers/listeners wired up yet. `libs/common-core` had no Kafka or Jackson dependency, and no test dependency/directory at all before this PR. So a couple of design calls below aren't dictated by existing code — happy to adjust if maintainers prefer differently.

## What changed

- **`JsonEventDeserializer`** (`com.codemonk.common.service`) implements `org.apache.kafka.common.serialization.Deserializer<Map<String, Object>>`. Returns `null` for `null` input (matches Kafka's own deserializer convention, e.g. `StringDeserializer`), otherwise parses the payload into a `Map<String, Object>` via Jackson, wrapping any parse failure in `org.apache.kafka.common.errors.SerializationException` (the standard exception type for this SPI).
- Annotated `@Component` per the issue's implementation guide. Note: a plain no-arg constructor is kept so it also works if Kafka instantiates it via reflection through the `value.deserializer` consumer config property, which is the more common way `Deserializer<T>` implementations get used.
- **`JsonConstants`** (`com.codemonk.common.constant`) holds a single shared `ObjectMapper` instance (`ObjectMapper` is thread-safe once configured and not cheap to construct repeatedly) so future JSON (de)serialization code in `common-core` can reuse it instead of each class building its own.
- Added `kafka-clients`, `jackson-databind`, and `spring-context` to `libs/common-core/pom.xml` (none were previously declared there); versions are all inherited from the root `spring-boot-starter-parent` BOM. Added `spring-boot-starter-test` (test scope) since the module had no test dependency or test sources before.

## Testing

- `JsonEventDeserializerTest` (6 cases): flat JSON object, nested objects/arrays, `null` input → `null`, malformed JSON → `SerializationException`, empty payload → `SerializationException`, JSON array instead of object → `SerializationException`.
- `mvn clean test` passes across the full reactor (all 10 modules).
