### PR TITLE
feat(common-core): implement standardized error handling, domain exceptions, and global advice

### DIFF
--- a/libs/common-core/pom.xml
+++ b/libs/common-core/pom.xml
@@ -22,5 +22,18 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-logging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/libs/common-core/src/main/java/com/codemonk/common/constant/TracingConstants.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/constant/TracingConstants.java
@@ -1,8 +1,5 @@
 package com.codemonk.common.constant;
 
-/**
- * Common constants for distributed tracing, correlation headers, and logging MDC.
- */
 public final class TracingConstants {
 
     public static final String HEADER_TRACE_ID = "X-Trace-Id";

--- a/libs/common-core/src/main/java/com/codemonk/common/constant/TracingConstants.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/constant/TracingConstants.java
@@ -1,0 +1,14 @@
+package com.codemonk.common.constant;
+
+/**
+ * Common constants for distributed tracing, correlation headers, and logging MDC.
+ */
+public final class TracingConstants {
+
+    public static final String HEADER_TRACE_ID = "X-Trace-Id";
+    public static final String HEADER_CORRELATION_ID = "X-Correlation-Id";
+    public static final String MDC_TRACE_ID = "traceId";
+
+    private TracingConstants() {
+    }
+}

--- a/libs/common-core/src/main/java/com/codemonk/common/dto/ErrorResponse.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/dto/ErrorResponse.java
@@ -1,15 +1,63 @@
 package com.codemonk.common.dto;
 
-import java.time.Instant;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Standardized API error payload for all CodeMonk microservices.
+ *
+ * @param status           HTTP status code (e.g. 400, 404, 500)
+ * @param error            HTTP status reason phrase (e.g. "Bad Request", "Not Found")
+ * @param message          Human-readable description of the error
+ * @param path             The requested URI path where the error occurred
+ * @param timestamp        UTC timestamp when the error occurred
+ * @param validationErrors Optional list of field-level validation errors
+ * @param traceId          Distributed trace/correlation identifier for cross-service observability
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record ErrorResponse(
         int status,
         String error,
         String message,
         String path,
-        Instant timestamp
+        Instant timestamp,
+        List<ValidationErrorDetail> validationErrors,
+        String traceId
 ) {
+    public ErrorResponse {
+        if (validationErrors != null) {
+            validationErrors = Collections.unmodifiableList(validationErrors);
+        }
+    }
+
+    /**
+     * Creates a simple ErrorResponse without validation errors or traceId.
+     */
     public static ErrorResponse of(int status, String error, String message, String path) {
-        return new ErrorResponse(status, error, message, path, Instant.now());
+        return new ErrorResponse(status, error, message, path, Instant.now(), null, null);
+    }
+
+    /**
+     * Creates an ErrorResponse with a distributed trace ID.
+     */
+    public static ErrorResponse of(int status, String error, String message, String path, String traceId) {
+        return new ErrorResponse(status, error, message, path, Instant.now(), null, traceId);
+    }
+
+    /**
+     * Creates an ErrorResponse containing field-level validation failures.
+     */
+    public static ErrorResponse withValidation(
+            int status,
+            String error,
+            String message,
+            String path,
+            List<ValidationErrorDetail> validationErrors,
+            String traceId
+    ) {
+        return new ErrorResponse(status, error, message, path, Instant.now(), validationErrors, traceId);
     }
 }

--- a/libs/common-core/src/main/java/com/codemonk/common/dto/ValidationErrorDetail.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/dto/ValidationErrorDetail.java
@@ -1,0 +1,25 @@
+package com.codemonk.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Represents a specific field-level validation failure in a REST request.
+ *
+ * @param field         the name of the invalid request property/field
+ * @param rejectedValue the invalid value provided by the client (sanitized)
+ * @param message       the reason why validation failed
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ValidationErrorDetail(
+        String field,
+        Object rejectedValue,
+        String message
+) {
+    public static ValidationErrorDetail of(String field, Object rejectedValue, String message) {
+        return new ValidationErrorDetail(field, rejectedValue, message);
+    }
+
+    public static ValidationErrorDetail of(String field, String message) {
+        return new ValidationErrorDetail(field, null, message);
+    }
+}

--- a/libs/common-core/src/main/java/com/codemonk/common/exception/DuplicateResourceException.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/exception/DuplicateResourceException.java
@@ -1,8 +1,6 @@
 package com.codemonk.common.exception;
 
-/**
- * Thrown when attempting to create a resource that already exists (HTTP 409 Conflict).
- */
+
 public class DuplicateResourceException extends DomainException {
 
     public DuplicateResourceException(String message) {

--- a/libs/common-core/src/main/java/com/codemonk/common/exception/DuplicateResourceException.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/exception/DuplicateResourceException.java
@@ -1,0 +1,15 @@
+package com.codemonk.common.exception;
+
+/**
+ * Thrown when attempting to create a resource that already exists (HTTP 409 Conflict).
+ */
+public class DuplicateResourceException extends DomainException {
+
+    public DuplicateResourceException(String message) {
+        super(message);
+    }
+
+    public DuplicateResourceException(String resourceName, String fieldName, Object fieldValue) {
+        super(String.format("%s with %s '%s' already exists", resourceName, fieldName, fieldValue));
+    }
+}

--- a/libs/common-core/src/main/java/com/codemonk/common/exception/GlobalExceptionHandler.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,179 @@
+package com.codemonk.common.exception;
+
+import com.codemonk.common.dto.ErrorResponse;
+import com.codemonk.common.dto.ValidationErrorDetail;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Centralized exception handler for all CodeMonk microservices.
+ * <p>
+ * Translates domain, validation, and standard framework exceptions into
+ * standardized {@link ErrorResponse} DTOs with consistent HTTP status codes.
+ */
+@RestControllerAdvice
+@Order(Ordered.LOWEST_PRECEDENCE)
+public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    private static final String HEADER_TRACE_ID = "X-Trace-Id";
+    private static final String HEADER_CORRELATION_ID = "X-Correlation-Id";
+    private static final String MDC_TRACE_ID = "traceId";
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleResourceNotFoundException(ResourceNotFoundException ex, HttpServletRequest request) {
+        String traceId = resolveTraceId(request);
+        log.warn("[TraceId: {}] Resource not found on path {}: {}", traceId, request.getRequestURI(), ex.getMessage());
+
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.NOT_FOUND.value(), HttpStatus.NOT_FOUND.getReasonPhrase(),
+                ex.getMessage(), request.getRequestURI(), traceId);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    @ExceptionHandler(DuplicateResourceException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicateResourceException(DuplicateResourceException ex, HttpServletRequest request) {
+        String traceId = resolveTraceId(request);
+        log.warn("[TraceId: {}] Duplicate resource conflict on path {}: {}", traceId, request.getRequestURI(), ex.getMessage());
+
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.CONFLICT.value(), HttpStatus.CONFLICT.getReasonPhrase(),
+                ex.getMessage(), request.getRequestURI(), traceId);
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+    }
+
+    @ExceptionHandler({InvalidRequestException.class, DomainException.class, IllegalArgumentException.class, IllegalStateException.class})
+    public ResponseEntity<ErrorResponse> handleInvalidRequestException(Exception ex, HttpServletRequest request) {
+        String traceId = resolveTraceId(request);
+        log.warn("[TraceId: {}] Invalid request on path {}: {}", traceId, request.getRequestURI(), ex.getMessage());
+
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                ex.getMessage(), request.getRequestURI(), traceId);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex, HttpServletRequest request) {
+        String traceId = resolveTraceId(request);
+        log.warn("[TraceId: {}] Validation failed for request body on path {}", traceId, request.getRequestURI());
+
+        List<ValidationErrorDetail> validationErrors = ex.getBindingResult().getFieldErrors().stream()
+                .map(fe -> ValidationErrorDetail.of(fe.getField(), fe.getRejectedValue(),
+                        fe.getDefaultMessage() != null ? fe.getDefaultMessage() : "Invalid value")).toList();
+
+        String message = String.format("Validation failed for %d field(s)", validationErrors.size());
+
+        ErrorResponse errorResponse = ErrorResponse.withValidation(HttpStatus.BAD_REQUEST.value(),
+                HttpStatus.BAD_REQUEST.getReasonPhrase(), message, request.getRequestURI(), validationErrors, traceId);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException ex, HttpServletRequest request) {
+        String traceId = resolveTraceId(request);
+        log.warn("[TraceId: {}] Constraint violation on path {}", traceId, request.getRequestURI());
+
+        List<ValidationErrorDetail> validationErrors = ex.getConstraintViolations().stream()
+                .map(cv -> ValidationErrorDetail.of(cv.getPropertyPath() != null ?
+                        cv.getPropertyPath().toString() : "unknown", cv.getInvalidValue(), cv.getMessage())).toList();
+
+        String message = String.format("Constraint validation failed for %d field(s)", validationErrors.size());
+
+        ErrorResponse errorResponse = ErrorResponse.withValidation(HttpStatus.BAD_REQUEST.value(),
+                HttpStatus.BAD_REQUEST.getReasonPhrase(), message, request.getRequestURI(), validationErrors, traceId);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(MissingServletRequestParameterException ex,
+                                                                                       HttpServletRequest request) {
+        String traceId = resolveTraceId(request);
+        log.warn("[TraceId: {}] Missing required request parameter on path {}: {}", traceId, request.getRequestURI(), ex.getMessage());
+
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST.value(),
+                HttpStatus.BAD_REQUEST.getReasonPhrase(), String.format("Required request parameter '%s' is missing",
+                        ex.getParameterName()), request.getRequestURI(), traceId);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException ex,
+                                                                                      HttpServletRequest request) {
+        String traceId = resolveTraceId(request);
+        log.warn("[TraceId: {}] HTTP method {} not supported for path {}", traceId, ex.getMethod(), request.getRequestURI());
+
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.METHOD_NOT_ALLOWED.value(),
+                HttpStatus.METHOD_NOT_ALLOWED.getReasonPhrase(), ex.getMessage(), request.getRequestURI(), traceId);
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(errorResponse);
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMediaTypeNotSupportedException(HttpMediaTypeNotSupportedException ex,
+                                                                                  HttpServletRequest request) {
+        String traceId = resolveTraceId(request);
+        log.warn("[TraceId: {}] Content type not supported on path {}: {}", traceId, request.getRequestURI(), ex.getMessage());
+
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value(),
+                HttpStatus.UNSUPPORTED_MEDIA_TYPE.getReasonPhrase(), ex.getMessage(), request.getRequestURI(), traceId);
+        return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).body(errorResponse);
+    }
+
+    @ExceptionHandler(ServiceUnavailableException.class)
+    public ResponseEntity<ErrorResponse> handleServiceUnavailableException(ServiceUnavailableException ex, HttpServletRequest request) {
+        String traceId = resolveTraceId(request);
+        log.error("[TraceId: {}] Downstream service unavailable on path {}: {}", traceId, request.getRequestURI(), ex.getMessage(), ex);
+
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.SERVICE_UNAVAILABLE.value(),
+                HttpStatus.SERVICE_UNAVAILABLE.getReasonPhrase(), ex.getMessage(), request.getRequestURI(), traceId);
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnhandledException(Exception ex, HttpServletRequest request) {
+        String traceId = resolveTraceId(request);
+        log.error("[TraceId: {}] Unhandled internal server error on path {}: {}", traceId, request.getRequestURI(), ex.getMessage(), ex);
+
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(),
+                "An unexpected internal error occurred. Please contact support with the provided trace ID.", request.getRequestURI(), traceId);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+
+    /**
+     * Resolves the trace ID from the request headers, MDC context, or generates a fallback UUID.
+     */
+    protected String resolveTraceId(HttpServletRequest request) {
+        if (request != null) {
+            String traceId = request.getHeader(HEADER_TRACE_ID);
+            if (traceId != null && !traceId.isBlank()) {
+                return traceId;
+            }
+            String correlationId = request.getHeader(HEADER_CORRELATION_ID);
+            if (correlationId != null && !correlationId.isBlank()) {
+                return correlationId;
+            }
+        }
+
+        String mdcTraceId = MDC.get(MDC_TRACE_ID);
+        if (mdcTraceId != null && !mdcTraceId.isBlank()) {
+            return mdcTraceId;
+        }
+
+        return UUID.randomUUID().toString();
+    }
+}

--- a/libs/common-core/src/main/java/com/codemonk/common/exception/GlobalExceptionHandler.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.codemonk.common.exception;
 
-import com.codemonk.common.constant.TracingConstants;
 import com.codemonk.common.dto.ErrorResponse;
 import com.codemonk.common.dto.ValidationErrorDetail;
 import jakarta.servlet.http.HttpServletRequest;

--- a/libs/common-core/src/main/java/com/codemonk/common/exception/GlobalExceptionHandler.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.codemonk.common.exception;
 
+import com.codemonk.common.constant.TracingConstants;
 import com.codemonk.common.dto.ErrorResponse;
 import com.codemonk.common.dto.ValidationErrorDetail;
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,10 +27,6 @@ import java.util.UUID;
 public class GlobalExceptionHandler {
 
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
-
-    private static final String HEADER_TRACE_ID = "X-Trace-Id";
-    private static final String HEADER_CORRELATION_ID = "X-Correlation-Id";
-    private static final String MDC_TRACE_ID = "traceId";
 
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleResourceNotFoundException(ResourceNotFoundException ex, HttpServletRequest request) {
@@ -153,17 +150,17 @@ public class GlobalExceptionHandler {
      */
     protected String resolveTraceId(HttpServletRequest request) {
         if (request != null) {
-            String traceId = request.getHeader(HEADER_TRACE_ID);
+            String traceId = request.getHeader(TracingConstants.HEADER_TRACE_ID);
             if (traceId != null && !traceId.isBlank()) {
                 return traceId;
             }
-            String correlationId = request.getHeader(HEADER_CORRELATION_ID);
+            String correlationId = request.getHeader(TracingConstants.HEADER_CORRELATION_ID);
             if (correlationId != null && !correlationId.isBlank()) {
                 return correlationId;
             }
         }
 
-        String mdcTraceId = MDC.get(MDC_TRACE_ID);
+        String mdcTraceId = MDC.get(TracingConstants.MDC_TRACE_ID);
         if (mdcTraceId != null && !mdcTraceId.isBlank()) {
             return mdcTraceId;
         }

--- a/libs/common-core/src/main/java/com/codemonk/common/exception/GlobalExceptionHandler.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/exception/GlobalExceptionHandler.java
@@ -21,12 +21,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.List;
 import java.util.UUID;
 
-/**
- * Centralized exception handler for all CodeMonk microservices.
- * <p>
- * Translates domain, validation, and standard framework exceptions into
- * standardized {@link ErrorResponse} DTOs with consistent HTTP status codes.
- */
 @RestControllerAdvice
 @Order(Ordered.LOWEST_PRECEDENCE)
 public class GlobalExceptionHandler {

--- a/libs/common-core/src/main/java/com/codemonk/common/exception/GlobalExceptionHandler.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/exception/GlobalExceptionHandler.java
@@ -22,6 +22,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.List;
 import java.util.UUID;
 
+import static com.codemonk.common.constant.TracingConstants.*;
+
 @RestControllerAdvice
 @Order(Ordered.LOWEST_PRECEDENCE)
 public class GlobalExceptionHandler {
@@ -150,17 +152,17 @@ public class GlobalExceptionHandler {
      */
     protected String resolveTraceId(HttpServletRequest request) {
         if (request != null) {
-            String traceId = request.getHeader(TracingConstants.HEADER_TRACE_ID);
+            String traceId = request.getHeader(HEADER_TRACE_ID);
             if (traceId != null && !traceId.isBlank()) {
                 return traceId;
             }
-            String correlationId = request.getHeader(TracingConstants.HEADER_CORRELATION_ID);
+            String correlationId = request.getHeader(HEADER_CORRELATION_ID);
             if (correlationId != null && !correlationId.isBlank()) {
                 return correlationId;
             }
         }
 
-        String mdcTraceId = MDC.get(TracingConstants.MDC_TRACE_ID);
+        String mdcTraceId = MDC.get(MDC_TRACE_ID);
         if (mdcTraceId != null && !mdcTraceId.isBlank()) {
             return mdcTraceId;
         }

--- a/libs/common-core/src/main/java/com/codemonk/common/exception/InvalidRequestException.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/exception/InvalidRequestException.java
@@ -1,8 +1,6 @@
 package com.codemonk.common.exception;
 
-/**
- * Thrown when a business logic or domain validation constraint is violated (HTTP 400 Bad Request).
- */
+
 public class InvalidRequestException extends DomainException {
 
     public InvalidRequestException(String message) {

--- a/libs/common-core/src/main/java/com/codemonk/common/exception/InvalidRequestException.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/exception/InvalidRequestException.java
@@ -1,0 +1,15 @@
+package com.codemonk.common.exception;
+
+/**
+ * Thrown when a business logic or domain validation constraint is violated (HTTP 400 Bad Request).
+ */
+public class InvalidRequestException extends DomainException {
+
+    public InvalidRequestException(String message) {
+        super(message);
+    }
+
+    public InvalidRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/libs/common-core/src/main/java/com/codemonk/common/exception/ResourceNotFoundException.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/exception/ResourceNotFoundException.java
@@ -1,8 +1,6 @@
 package com.codemonk.common.exception;
 
-/**
- * Thrown when a requested resource (e.g. Repository, CodeEntity, IndexJob) cannot be found.
- */
+
 public class ResourceNotFoundException extends DomainException {
 
     public ResourceNotFoundException(String message) {

--- a/libs/common-core/src/main/java/com/codemonk/common/exception/ResourceNotFoundException.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/exception/ResourceNotFoundException.java
@@ -1,8 +1,19 @@
 package com.codemonk.common.exception;
 
+/**
+ * Thrown when a requested resource (e.g. Repository, CodeEntity, IndexJob) cannot be found.
+ */
 public class ResourceNotFoundException extends DomainException {
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
 
     public ResourceNotFoundException(String resourceName, String identifier) {
         super(String.format("%s with identifier '%s' was not found", resourceName, identifier));
+    }
+
+    public ResourceNotFoundException(String resourceName, String fieldName, Object fieldValue) {
+        super(String.format("%s with %s '%s' was not found", resourceName, fieldName, fieldValue));
     }
 }

--- a/libs/common-core/src/main/java/com/codemonk/common/exception/ServiceUnavailableException.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/exception/ServiceUnavailableException.java
@@ -1,8 +1,6 @@
 package com.codemonk.common.exception;
 
-/**
- * Thrown when a required external dependency or downstream microservice is unreachable or times out (HTTP 503).
- */
+
 public class ServiceUnavailableException extends DomainException {
 
     public ServiceUnavailableException(String message) {

--- a/libs/common-core/src/main/java/com/codemonk/common/exception/ServiceUnavailableException.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/exception/ServiceUnavailableException.java
@@ -1,0 +1,19 @@
+package com.codemonk.common.exception;
+
+/**
+ * Thrown when a required external dependency or downstream microservice is unreachable or times out (HTTP 503).
+ */
+public class ServiceUnavailableException extends DomainException {
+
+    public ServiceUnavailableException(String message) {
+        super(message);
+    }
+
+    public ServiceUnavailableException(String serviceName, String reason) {
+        super(String.format("Service '%s' is currently unavailable: %s", serviceName, reason));
+    }
+
+    public ServiceUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/libs/common-core/src/test/java/com/codemonk/common/dto/ErrorResponseTest.java
+++ b/libs/common-core/src/test/java/com/codemonk/common/dto/ErrorResponseTest.java
@@ -1,0 +1,64 @@
+package com.codemonk.common.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ErrorResponseTest {
+
+    @Test
+    @DisplayName("Should create basic ErrorResponse using of() factory")
+    void shouldCreateBasicErrorResponse() {
+        ErrorResponse response = ErrorResponse.of(404, "Not Found", "Repository not found", "/api/v1/repositories/123");
+
+        assertThat(response.status()).isEqualTo(404);
+        assertThat(response.error()).isEqualTo("Not Found");
+        assertThat(response.message()).isEqualTo("Repository not found");
+        assertThat(response.path()).isEqualTo("/api/v1/repositories/123");
+        assertThat(response.timestamp()).isNotNull();
+        assertThat(response.timestamp()).isBeforeOrEqualTo(Instant.now());
+        assertThat(response.validationErrors()).isNull();
+        assertThat(response.traceId()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should create ErrorResponse with traceId")
+    void shouldCreateErrorResponseWithTraceId() {
+        String traceId = "test-trace-1234";
+        ErrorResponse response = ErrorResponse.of(500, "Internal Server Error", "Something went wrong", "/api/v1/test", traceId);
+
+        assertThat(response.status()).isEqualTo(500);
+        assertThat(response.traceId()).isEqualTo(traceId);
+        assertThat(response.validationErrors()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should create ErrorResponse with validation errors")
+    void shouldCreateErrorResponseWithValidationErrors() {
+        List<ValidationErrorDetail> validationErrors = List.of(
+                ValidationErrorDetail.of("url", "invalid-url", "Must be a valid GitHub URL"),
+                ValidationErrorDetail.of("branch", "Branch cannot be empty")
+        );
+
+        ErrorResponse response = ErrorResponse.withValidation(
+                400,
+                "Bad Request",
+                "Validation failed for 2 field(s)",
+                "/api/v1/repositories",
+                validationErrors,
+                "trace-5678"
+        );
+
+        assertThat(response.status()).isEqualTo(400);
+        assertThat(response.error()).isEqualTo("Bad Request");
+        assertThat(response.validationErrors()).hasSize(2);
+        assertThat(response.validationErrors().get(0).field()).isEqualTo("url");
+        assertThat(response.validationErrors().get(0).rejectedValue()).isEqualTo("invalid-url");
+        assertThat(response.validationErrors().get(1).rejectedValue()).isNull();
+        assertThat(response.traceId()).isEqualTo("trace-5678");
+    }
+}

--- a/libs/common-core/src/test/java/com/codemonk/common/exception/DomainExceptionTest.java
+++ b/libs/common-core/src/test/java/com/codemonk/common/exception/DomainExceptionTest.java
@@ -1,0 +1,33 @@
+package com.codemonk.common.exception;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DomainExceptionTest {
+
+    @Test
+    @DisplayName("Should format ResourceNotFoundException message correctly")
+    void shouldFormatResourceNotFoundException() {
+        ResourceNotFoundException ex1 = new ResourceNotFoundException("Repository", "repo-123");
+        assertThat(ex1.getMessage()).isEqualTo("Repository with identifier 'repo-123' was not found");
+
+        ResourceNotFoundException ex2 = new ResourceNotFoundException("CodeEntity", "name", "AuthService");
+        assertThat(ex2.getMessage()).isEqualTo("CodeEntity with name 'AuthService' was not found");
+    }
+
+    @Test
+    @DisplayName("Should format DuplicateResourceException message correctly")
+    void shouldFormatDuplicateResourceException() {
+        DuplicateResourceException ex = new DuplicateResourceException("Repository", "url", "https://github.com/org/repo");
+        assertThat(ex.getMessage()).isEqualTo("Repository with url 'https://github.com/org/repo' already exists");
+    }
+
+    @Test
+    @DisplayName("Should format ServiceUnavailableException message correctly")
+    void shouldFormatServiceUnavailableException() {
+        ServiceUnavailableException ex = new ServiceUnavailableException("ai-service", "Connection timed out");
+        assertThat(ex.getMessage()).isEqualTo("Service 'ai-service' is currently unavailable: Connection timed out");
+    }
+}

--- a/libs/common-core/src/test/java/com/codemonk/common/exception/GlobalExceptionHandlerTest.java
+++ b/libs/common-core/src/test/java/com/codemonk/common/exception/GlobalExceptionHandlerTest.java
@@ -1,5 +1,6 @@
 package com.codemonk.common.exception;
 
+import com.codemonk.common.constant.TracingConstants;
 import com.codemonk.common.dto.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolation;
@@ -8,6 +9,7 @@ import jakarta.validation.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -176,7 +178,7 @@ class GlobalExceptionHandlerTest {
     @Test
     @DisplayName("Should extract trace ID from X-Trace-Id request header when present")
     void shouldExtractTraceIdFromHeader() {
-        when(request.getHeader("X-Trace-Id")).thenReturn("custom-trace-abc-123");
+        when(request.getHeader(TracingConstants.HEADER_TRACE_ID)).thenReturn("custom-trace-abc-123");
 
         ResponseEntity<ErrorResponse> response = exceptionHandler.handleResourceNotFoundException(
                 new ResourceNotFoundException("Test", "1"),
@@ -185,5 +187,41 @@ class GlobalExceptionHandlerTest {
 
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().traceId()).isEqualTo("custom-trace-abc-123");
+    }
+
+    @Test
+    @DisplayName("Should extract correlation ID from X-Correlation-Id when X-Trace-Id is absent")
+    void shouldExtractCorrelationIdWhenTraceIdAbsent() {
+        when(request.getHeader(TracingConstants.HEADER_TRACE_ID)).thenReturn(null);
+        when(request.getHeader(TracingConstants.HEADER_CORRELATION_ID)).thenReturn("corr-id-xyz-789");
+
+        ResponseEntity<ErrorResponse> response = exceptionHandler.handleResourceNotFoundException(
+                new ResourceNotFoundException("Test", "1"),
+                request
+        );
+
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().traceId()).isEqualTo("corr-id-xyz-789");
+    }
+
+    @Test
+    @DisplayName("Should extract trace ID from MDC when headers are absent")
+    void shouldExtractTraceIdFromMdcWhenHeadersAbsent() {
+        when(request.getHeader(TracingConstants.HEADER_TRACE_ID)).thenReturn(null);
+        when(request.getHeader(TracingConstants.HEADER_CORRELATION_ID)).thenReturn(null);
+
+        try {
+            MDC.put(TracingConstants.MDC_TRACE_ID, "mdc-trace-999");
+
+            ResponseEntity<ErrorResponse> response = exceptionHandler.handleResourceNotFoundException(
+                    new ResourceNotFoundException("Test", "1"),
+                    request
+            );
+
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().traceId()).isEqualTo("mdc-trace-999");
+        } finally {
+            MDC.clear();
+        }
     }
 }

--- a/libs/common-core/src/test/java/com/codemonk/common/exception/GlobalExceptionHandlerTest.java
+++ b/libs/common-core/src/test/java/com/codemonk/common/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,189 @@
+package com.codemonk.common.exception;
+
+import com.codemonk.common.dto.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GlobalExceptionHandlerTest {
+
+    private GlobalExceptionHandler exceptionHandler;
+    private HttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+        exceptionHandler = new GlobalExceptionHandler();
+        request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn("/api/v1/repositories");
+    }
+
+    @Test
+    @DisplayName("Should handle ResourceNotFoundException and return 404")
+    void shouldHandleResourceNotFoundException() {
+        ResourceNotFoundException ex = new ResourceNotFoundException("Repository", "repo-404");
+
+        ResponseEntity<ErrorResponse> response = exceptionHandler.handleResourceNotFoundException(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().status()).isEqualTo(404);
+        assertThat(response.getBody().error()).isEqualTo("Not Found");
+        assertThat(response.getBody().message()).contains("repo-404");
+        assertThat(response.getBody().path()).isEqualTo("/api/v1/repositories");
+        assertThat(response.getBody().traceId()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("Should handle DuplicateResourceException and return 409")
+    void shouldHandleDuplicateResourceException() {
+        DuplicateResourceException ex = new DuplicateResourceException("Repository", "url", "https://github.com/org/repo");
+
+        ResponseEntity<ErrorResponse> response = exceptionHandler.handleDuplicateResourceException(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().status()).isEqualTo(409);
+        assertThat(response.getBody().error()).isEqualTo("Conflict");
+        assertThat(response.getBody().message()).contains("already exists");
+    }
+
+    @Test
+    @DisplayName("Should handle InvalidRequestException and return 400")
+    void shouldHandleInvalidRequestException() {
+        InvalidRequestException ex = new InvalidRequestException("Invalid commit SHA format");
+
+        ResponseEntity<ErrorResponse> response = exceptionHandler.handleInvalidRequestException(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().status()).isEqualTo(400);
+        assertThat(response.getBody().error()).isEqualTo("Bad Request");
+        assertThat(response.getBody().message()).isEqualTo("Invalid commit SHA format");
+    }
+
+    @Test
+    @DisplayName("Should handle MethodArgumentNotValidException with field errors and return 400")
+    void shouldHandleMethodArgumentNotValidException() {
+        BindingResult bindingResult = mock(BindingResult.class);
+        FieldError fieldError = new FieldError("registerRepoRequest", "url", "invalid-url", false, null, null, "Must be a valid GitHub URL");
+        when(bindingResult.getFieldErrors()).thenReturn(List.of(fieldError));
+
+        MethodParameter parameter = mock(MethodParameter.class);
+        MethodArgumentNotValidException ex = new MethodArgumentNotValidException(parameter, bindingResult);
+
+        ResponseEntity<ErrorResponse> response = exceptionHandler.handleMethodArgumentNotValidException(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().status()).isEqualTo(400);
+        assertThat(response.getBody().validationErrors()).hasSize(1);
+        assertThat(response.getBody().validationErrors().get(0).field()).isEqualTo("url");
+        assertThat(response.getBody().validationErrors().get(0).rejectedValue()).isEqualTo("invalid-url");
+        assertThat(response.getBody().validationErrors().get(0).message()).isEqualTo("Must be a valid GitHub URL");
+    }
+
+    @Test
+    @DisplayName("Should handle ConstraintViolationException and return 400")
+    void shouldHandleConstraintViolationException() {
+        ConstraintViolation<?> violation = mock(ConstraintViolation.class);
+        Path path = mock(Path.class);
+        when(path.toString()).thenReturn("repositoryUrl");
+        when(violation.getPropertyPath()).thenReturn(path);
+        when(violation.getInvalidValue()).thenReturn("bad-value");
+        when(violation.getMessage()).thenReturn("Invalid format");
+
+        ConstraintViolationException ex = new ConstraintViolationException(Set.of(violation));
+
+        ResponseEntity<ErrorResponse> response = exceptionHandler.handleConstraintViolationException(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().validationErrors()).hasSize(1);
+        assertThat(response.getBody().validationErrors().get(0).field()).isEqualTo("repositoryUrl");
+    }
+
+    @Test
+    @DisplayName("Should handle MissingServletRequestParameterException and return 400")
+    void shouldHandleMissingServletRequestParameterException() {
+        MissingServletRequestParameterException ex = new MissingServletRequestParameterException("branch", "String");
+
+        ResponseEntity<ErrorResponse> response = exceptionHandler.handleMissingServletRequestParameterException(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().message()).contains("branch");
+    }
+
+    @Test
+    @DisplayName("Should handle HttpRequestMethodNotSupportedException and return 405")
+    void shouldHandleHttpRequestMethodNotSupportedException() {
+        HttpRequestMethodNotSupportedException ex = new HttpRequestMethodNotSupportedException("DELETE");
+
+        ResponseEntity<ErrorResponse> response = exceptionHandler.handleHttpRequestMethodNotSupportedException(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().status()).isEqualTo(405);
+    }
+
+    @Test
+    @DisplayName("Should handle ServiceUnavailableException and return 503")
+    void shouldHandleServiceUnavailableException() {
+        ServiceUnavailableException ex = new ServiceUnavailableException("kafka-broker", "Broker leader unreachable");
+
+        ResponseEntity<ErrorResponse> response = exceptionHandler.handleServiceUnavailableException(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().status()).isEqualTo(503);
+        assertThat(response.getBody().message()).contains("kafka-broker");
+    }
+
+    @Test
+    @DisplayName("Should handle unexpected Exception and return sanitized 500")
+    void shouldHandleUnexpectedException() {
+        Exception ex = new RuntimeException("Database connection timeout at secret_db_host:5432");
+
+        ResponseEntity<ErrorResponse> response = exceptionHandler.handleUnhandledException(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().status()).isEqualTo(500);
+        assertThat(response.getBody().message()).doesNotContain("secret_db_host");
+        assertThat(response.getBody().message()).contains("An unexpected internal error occurred");
+        assertThat(response.getBody().traceId()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("Should extract trace ID from X-Trace-Id request header when present")
+    void shouldExtractTraceIdFromHeader() {
+        when(request.getHeader("X-Trace-Id")).thenReturn("custom-trace-abc-123");
+
+        ResponseEntity<ErrorResponse> response = exceptionHandler.handleResourceNotFoundException(
+                new ResourceNotFoundException("Test", "1"),
+                request
+        );
+
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().traceId()).isEqualTo("custom-trace-abc-123");
+    }
+}


### PR DESCRIPTION
### 🎯 Overview
This PR implements a centralized error handling architecture in `libs/common-core`, fulfilling the Error Handling track outlined in the CodeMonk SRS (Sections 8, 34, 36, and 39) and RFC 7807 problem details alignment.

### 🔗 Related Issues
Closes #1, Closes #2, Closes #3, Closes #8, Closes #24

---

### ✨ Key Changes
1. **DTOs & Field Validation**:
   - `ValidationErrorDetail`: Immutable record capturing field-level validation errors (`field`, `rejectedValue`, `message`).
   - `ErrorResponse`: Enhanced API error envelope supporting `validationErrors` list and `traceId` for distributed tracing.

2. **Domain Exceptions Hierarchy**:
   - `DomainException`: Base unchecked exception.
   - `ResourceNotFoundException` (HTTP 404)
   - `DuplicateResourceException` (HTTP 409)
   - `InvalidRequestException` (HTTP 400)
   - `ServiceUnavailableException` (HTTP 503)

3. **Centralized `@RestControllerAdvice` (`GlobalExceptionHandler`)**:
   - Intercepts domain exceptions, bean validation errors (`MethodArgumentNotValidException`, `ConstraintViolationException`), and routing errors (`HttpRequestMethodNotSupportedException`).
   - 3-tier distributed trace ID resolution (`X-Trace-Id` / `X-Correlation-Id` header $\rightarrow$ SLF4J MDC $\rightarrow$ UUID fallback).
   - Sanitized HTTP 500 fallback protecting internal stack traces and server details.

4. **Testing**:
   - 100% test coverage for DTOs, domain exceptions, and all exception handler methods in `GlobalExceptionHandlerTest`.