### PR TITLE
feat: add documentation entity

### DIFF
--- a/libs/common-core/pom.xml
+++ b/libs/common-core/pom.xml
@@ -40,5 +40,9 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/libs/common-core/src/main/java/com/codemonk/common/service/DocumentationEntity.java
+++ b/libs/common-core/src/main/java/com/codemonk/common/service/DocumentationEntity.java
@@ -1,0 +1,81 @@
+package com.codemonk.common.service;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class DocumentationEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String repositoryId;
+    private String docType;
+    private String title;
+    private String markdownContent;
+    private String status;
+
+    public DocumentationEntity() {
+    }
+
+    public DocumentationEntity(String repositoryId, String docType,
+            String title, String markdownContent, String status) {
+        this.repositoryId = repositoryId;
+        this.docType = docType;
+        this.title = title;
+        this.markdownContent = markdownContent;
+        this.status = status;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getRepositoryId() {
+        return repositoryId;
+    }
+
+    public void setRepositoryId(String repositoryId) {
+        this.repositoryId = repositoryId;
+    }
+
+    public String getDocType() {
+        return docType;
+    }
+
+    public void setDocType(String docType) {
+        this.docType = docType;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getMarkdownContent() {
+        return markdownContent;
+    }
+
+    public void setMarkdownContent(String markdownContent) {
+        this.markdownContent = markdownContent;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+}


### PR DESCRIPTION
## Summary
- Add DocumentationEntity JPA entity
- Add Spring Data JPA dependency to common-core
- Add required fields, constructor, getters and setters

## Testing
- `mvn test -pl libs/common-core`
- 6 tests passed
- BUILD SUCCESS

Closes #323