### PR TITLE
feat: add documentation repository

### DIFF
--- a/services/repository-service/src/main/java/com/codemonk/repository/RepositoryApplication.java
+++ b/services/repository-service/src/main/java/com/codemonk/repository/RepositoryApplication.java
@@ -1,14 +1,18 @@
 package com.codemonk.repository;
 
+import com.codemonk.common.service.DocumentationEntity;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @SpringBootApplication
+@EntityScan(basePackageClasses = DocumentationEntity.class)
 @EnableDiscoveryClient
 public class RepositoryApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(RepositoryApplication.class, args);
     }
+
 }

--- a/services/repository-service/src/main/java/com/codemonk/repository/service/DocumentationRepository.java
+++ b/services/repository-service/src/main/java/com/codemonk/repository/service/DocumentationRepository.java
@@ -1,0 +1,11 @@
+package com.codemonk.repository.service;
+
+import com.codemonk.common.service.DocumentationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DocumentationRepository extends JpaRepository<DocumentationEntity, Long> {
+
+    List<DocumentationEntity> findByRepositoryId(String repositoryId);
+}


### PR DESCRIPTION
## Summary

- Add DocumentationRepository JPA repository
- Add repository lookup by repositoryId
- Configure entity scanning for DocumentationEntity

## Testing

- `mvn test -pl services/repository-service -am`
- 25 tests passed
- BUILD SUCCESS

Closes #324